### PR TITLE
359.http api layout plus klein

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,9 @@ jobs:
           # in the project source checkout.
           path: "/tmp/project/_trial_temp/test.log"
 
+      - store_artifacts: &STORE_ELIOT_LOG
+          path: "/tmp/project/eliot.log"
+
       - store_artifacts: &STORE_OTHER_ARTIFACTS
           # Store any other artifacts, too.  This is handy to allow other jobs
           # sharing most of the definition of this one to be able to
@@ -313,6 +316,7 @@ jobs:
       - run: *RUN_TESTS
       - store_test_results: *STORE_TEST_RESULTS
       - store_artifacts: *STORE_TEST_LOG
+      - store_artifacts: *STORE_ELIOT_LOG
       - store_artifacts: *STORE_OTHER_ARTIFACTS
       - run: *SUBMIT_COVERAGE
 

--- a/.circleci/populate-wheelhouse.sh
+++ b/.circleci/populate-wheelhouse.sh
@@ -13,7 +13,7 @@ TEST_DEPS="tox codecov"
 
 # Python packages we need to generate test reports for CI infrastructure.
 # *Not* packages Tahoe-LAFS itself (implement or test suite) need.
-REPORTING_DEPS="python-subunit junitxml subunitreporter"
+REPORTING_DEPS="python-subunit junitxml subunitreporter eliot eliot-tree"
 
 # The filesystem location of the wheelhouse which we'll populate with wheels
 # for all of our dependencies.

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -81,6 +81,9 @@ ${TIMEOUT} "${BOOTSTRAP_VENV}"/bin/tox \
     ${MAGIC_FOLDER_TOX_ARGS} || "${alternative}"
 
 if [ -n "${ARTIFACTS}" ]; then
+    "${BOOTSTRAP_VENV}"/bin/eliot-prettyprint < "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot.txt
+    "${BOOTSTRAP_VENV}"/bin/eliot-tree --field-limit=0 --color=always "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot-tree.txt
+
     # Create a junitxml results area.
     mkdir -p "$(dirname "${JUNITXML}")"
     "${BOOTSTRAP_VENV}"/bin/subunit2junitxml < "${SUBUNIT2}" > "${JUNITXML}" || "${alternative}"

--- a/.circleci/setup-virtualenv.sh
+++ b/.circleci/setup-virtualenv.sh
@@ -40,3 +40,6 @@ export PIP_FIND_LINKS="file://${WHEELHOUSE_PATH}"
      --notest \
      -e "${MAGIC_FOLDER_TOX_ENVIRONMENT}" \
      ${MAGIC_FOLDER_TOX_ARGS}
+
+#FIXME: build new images with these
+"${BOOTSTRAP_VENV}"/bin/pip install eliot eliot-tree

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,10 @@ install_requires = [
 
     # Python utilities that were originally extracted from tahoe
     # We use them directly, rather than the re-exports from allmydata
-    "pyutil >= 3.3.0"
+    "pyutil >= 3.3.0",
+
+    # last py2 release of klein
+    "klein==20.6.0",
 ]
 
 setup_requires = [

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -217,7 +217,7 @@ def create_testing_http_client(reactor, config, global_service, get_api_token, t
         in-memory objects. These objects obtain their data from the
         service provided
     """
-    v1_resource = APIv1(config, global_service, tahoe_client)
+    v1_resource = APIv1(config, global_service, tahoe_client).app.resource()
     root = magic_folder_resource(get_api_token, v1_resource)
     client = HTTPClient(
         agent=RequestTraversalAgent(root),

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -122,12 +122,12 @@ class MagicFolderClient(object):
         return self._authorized_request("GET", api_url)
 
     def add_snapshot(self, magic_folder, path):
-        api_url = self.base_url.child(u'v1').child(u'snapshot').child(magic_folder)
+        api_url = self.base_url.child(u'v1', u'magic-folder', magic_folder, u'snapshot')
         api_url = api_url.set(u'path', path)
         return self._authorized_request("POST", api_url)
 
     def add_participant(self, magic_folder, author_name, personal_dmd):
-        api_url = self.base_url.child(u'v1').child(u'participants').child(magic_folder)
+        api_url = self.base_url.child(u'v1', u'magic-folder', magic_folder, u'participants')
         body = json.dumps({
             "author": {
                 "name": author_name,
@@ -139,7 +139,7 @@ class MagicFolderClient(object):
         return self._authorized_request("POST", api_url, body=body.encode("utf8"))
 
     def list_participants(self, magic_folder):
-        api_url = self.base_url.child(u'v1').child(u'participants').child(magic_folder)
+        api_url = self.base_url.child(u'v1', u'magic-folder', magic_folder, u'participants')
         return self._authorized_request("GET", api_url)
 
     @inlineCallbacks

--- a/src/magic_folder/test/test_api_cli.py
+++ b/src/magic_folder/test/test_api_cli.py
@@ -95,7 +95,7 @@ class TestApiAddSnapshot(AsyncTestCase):
             # ((method, url, params, headers, data), (code, headers, body)),
             (
                 (b"post",
-                 self.url.child("snapshot").child("default").to_text().encode("utf8"),
+                 self.url.child("magic-folder", "default", "snapshot").to_text().encode("utf8"),
                  {b"path": [b"foo"]},
                  {
                      b'Host': [b'invalid.'],
@@ -149,7 +149,7 @@ class TestApiAddSnapshot(AsyncTestCase):
             # ((method, url, params, headers, data), (code, headers, body)),
             (
                 (b"post",
-                 self.url.child("magic-folder").child("default").child("snapshot").to_text().encode("utf8"),
+                 self.url.child("magic-folder", "default", "snapshot").to_text().encode("utf8"),
                  {b"path": [b"../../../foo"]},
                  {
                      b'Host': [b'invalid.'],
@@ -419,7 +419,7 @@ class TestMagicApi(AsyncTestCase):
             # ((method, url, params, headers, data), (code, headers, body)),
             (
                 (b"post",
-                 self.url.child("snapshot").child("default").to_text().encode("utf8"),
+                 self.url.child("magic-folder", "default", "snapshot").to_text().encode("utf8"),
                  {b"path": [b"foo"]},
                  {
                      b'Host': [b'invalid.'],
@@ -658,7 +658,7 @@ class TestApiParticipants(AsyncTestCase):
             (
                 # expected request
                 (b"post",
-                 self.url.child("participants").child("default").to_text().encode("utf8"),
+                 self.url.child("magic-folder", "default", "participants").to_text().encode("utf8"),
                  {},
                  {
                      b'Host': [b'invalid.'],
@@ -748,7 +748,7 @@ class TestApiParticipants(AsyncTestCase):
             (
                 # expected request
                 (b"get",
-                 self.url.child("participants").child("default").to_text().encode("utf8"),
+                 self.url.child("magic-folder", "default", "participants").to_text().encode("utf8"),
                  {},
                  {
                      b'Host': [b'invalid.'],

--- a/src/magic_folder/test/test_api_cli.py
+++ b/src/magic_folder/test/test_api_cli.py
@@ -149,7 +149,7 @@ class TestApiAddSnapshot(AsyncTestCase):
             # ((method, url, params, headers, data), (code, headers, body)),
             (
                 (b"post",
-                 self.url.child("snapshot").child("default").to_text().encode("utf8"),
+                 self.url.child("magic-folder").child("default").child("snapshot").to_text().encode("utf8"),
                  {b"path": [b"../../../foo"]},
                  {
                      b'Host': [b'invalid.'],

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -681,6 +681,32 @@ class CreateSnapshotTests(SyncTestCase):
             ),
         )
 
+    def test_create_snapshot_no_folder(self):
+        """
+        A **POST** to **/v1/snapshot/:folder-name** for an unknown folder
+        produces a 404
+        """
+        treq = treq_for_folders(
+            Clock(),
+            FilePath(self.mktemp()),
+            AUTH_TOKEN,
+            {},
+            start_folder_services=True,
+        )
+        self.assertThat(
+            authorized_request(
+                treq,
+                AUTH_TOKEN,
+                b"POST",
+                self.url.child("not-a-folder", "snapshot")
+            ),
+            succeeded(
+                matches_response(
+                    code_matcher=Equals(NOT_FOUND),
+                ),
+            ),
+        )
+
 
 class ParticipantsTests(SyncTestCase):
     """

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -464,7 +464,7 @@ class CreateSnapshotTests(SyncTestCase):
     Tests for creating a new snapshot in an existing Magic Folder using a
     **POST**.
     """
-    url = DecodedURL.from_text(u"http://example.invalid./v1/snapshot")
+    url = DecodedURL.from_text(u"http://example.invalid./v1/magic-folder")
 
     @given(
         local_authors(),
@@ -504,7 +504,7 @@ class CreateSnapshotTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name).set(u"path", path_in_folder),
+                self.url.child(folder_name, "snapshot").set(u"path", path_in_folder),
             ),
             has_no_result(),
         )
@@ -542,7 +542,7 @@ class CreateSnapshotTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name).set(u"path", path_in_folder),
+                self.url.child(folder_name, "snapshot").set(u"path", path_in_folder),
             ),
             succeeded(
                 matches_response(
@@ -570,7 +570,7 @@ class CreateSnapshotTests(SyncTestCase):
     )
     def test_create_snapshot(self, author, folder_name, path_in_folder, some_content):
         """
-        A **POST** to **/v1/snapshot/:folder-name** with a **path** query argument
+        A **POST** to **/v1/magic-folder/:folder-name/snapshot** with a **path** query argument
         creates a new local snapshot for the file at the given path in the
         named folder.
         """
@@ -596,7 +596,7 @@ class CreateSnapshotTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name).set(u"path", path_in_folder),
+                self.url.child(folder_name, "snapshot").set(u"path", path_in_folder),
             ),
             succeeded(
                 matches_response(
@@ -610,7 +610,7 @@ class CreateSnapshotTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"GET",
-                self.url,
+                DecodedURL.from_text(u"http://example.invalid./v1/snapshots")
             ),
             succeeded(
                 matches_response(
@@ -672,7 +672,7 @@ class CreateSnapshotTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name).set(u"path", path_outside_folder),
+                self.url.child(folder_name, "snapshot").set(u"path", path_outside_folder),
             ),
             succeeded(
                 matches_response(
@@ -686,7 +686,7 @@ class ParticipantsTests(SyncTestCase):
     """
     Tests relating to the '/v1/participants/<folder>` API
     """
-    url = DecodedURL.from_text(u"http://example.invalid./v1/participants")
+    url = DecodedURL.from_text(u"http://example.invalid./v1/magic-folder")
 
     def test_participants_no_folder(self):
         """
@@ -714,7 +714,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"GET",
-                self.url.child("a-folder-that-doesnt-exist"),
+                self.url.child("a-folder-that-doesnt-exist", "participants"),
             ),
             succeeded(
                 matches_response(
@@ -778,7 +778,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name),
+                self.url.child(folder_name, "participants"),
                 dumps({
                     "author": {"name": "kelly"},
                     "personal_dmd": personal_dmd,
@@ -802,7 +802,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"GET",
-                self.url.child(folder_name),
+                self.url.child(folder_name, "participants"),
             ),
             succeeded(
                 matches_response(
@@ -869,7 +869,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name),
+                self.url.child(folder_name, "participants"),
                 dumps({
                     "not-the-author": {"name": "kelly"},
                 }).encode("utf8")
@@ -932,7 +932,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name),
+                self.url.child(folder_name, "participants"),
                 dumps({
                     "author": {"not-the-name": "kelly"},
                     "personal_dmd": "fake",
@@ -998,7 +998,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name),
+                self.url.child(folder_name, "participants"),
                 dumps({
                     "author": {"name": "kelly"},
                     "personal_dmd": personal_dmd,
@@ -1063,7 +1063,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name),
+                self.url.child(folder_name, "participants"),
                 dumps({
                     "author": {"name": "kelly"},
                     "personal_dmd": personal_dmd,
@@ -1122,7 +1122,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"GET",
-                self.url.child(folder_name),
+                self.url.child(folder_name, "participants"),
             ),
             succeeded(
                 matches_response(
@@ -1178,7 +1178,7 @@ class ParticipantsTests(SyncTestCase):
                 treq,
                 AUTH_TOKEN,
                 b"POST",
-                self.url.child(folder_name),
+                self.url.child(folder_name, "participants"),
                 dumps({
                     "author": {"name": "kelly"},
                     "personal_dmd": personal_dmd,

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -142,6 +142,15 @@ class APIv1(object):
 
     app = Klein()
 
+    @app.handle_errors(Exception)
+    def internal_error(self, request, failure):
+        from eliot import writeFailure
+        writeFailure(failure)
+        request.setResponseCode(http.INTERNAL_SERVER_ERROR)
+        _application_json(request)
+        return b"{}"
+
+
     @app.route("/participants/<string:folder_name>", methods=['GET'])
     @inlineCallbacks
     def list_participants(self, request, folder_name):

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -148,10 +148,10 @@ class APIv1(object):
         writeFailure(failure)
         request.setResponseCode(http.INTERNAL_SERVER_ERROR)
         _application_json(request)
-        return b"{}"
+        return json.dumps({"reason": "unexpected error"}).encode("utf8")
 
 
-    @app.route("/participants/<string:folder_name>", methods=['GET'])
+    @app.route("/magic-folder/<string:folder_name>/participants", methods=['GET'])
     @inlineCallbacks
     def list_participants(self, request, folder_name):
         """
@@ -187,7 +187,7 @@ class APIv1(object):
         _application_json(request)
         returnValue(json.dumps(reply, ensure_ascii=False).encode("utf8"))
 
-    @app.route("/participants/<string:folder_name>", methods=['POST'])
+    @app.route("/magic-folder/<string:folder_name>/participants", methods=['POST'])
     @inlineCallbacks
     def add_participant(self, request, folder_name):
         """
@@ -261,7 +261,7 @@ class APIv1(object):
         _application_json(request)
         return json.dumps(dict(_list_all_snapshots(self._global_config)))
 
-    @app.route("/snapshot/<string:folder_name>", methods=['POST'])
+    @app.route("/magic-folder/<string:folder_name>/snapshot", methods=['POST'])
     @inlineCallbacks
     def add_snapshot(self, request, folder_name):
         """
@@ -337,15 +337,11 @@ class APIv1(object):
         })
 
 
-
-
 class _InputError(ValueError):
     """
     Local errors with our input validation to report back to HTTP
     clients.
     """
-
-
 
 def _application_json(request):
     request.responseHeaders.setRawHeaders(u"content-type", [u"application/json"])

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -128,6 +128,9 @@ class BearerTokenAuthorization(Resource, object):
         return Unauthorized()
 
 
+from werkzeug.exceptions import HTTPException
+
+
 @attr.s
 class APIv1(object):
     """
@@ -141,6 +144,12 @@ class APIv1(object):
     _tahoe_client = attr.ib()
 
     app = Klein()
+
+    @app.handle_errors(HTTPException)
+    def internal_error(self, request, failure):
+        request.setResponseCode(failure.value.code or INTERNAL_SERVER_ERROR)
+        _application_json(request)
+        return json.dumps({"reason": failure.value.description}).encode("utf8")
 
     @app.handle_errors(Exception)
     def internal_error(self, request, failure):

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -17,7 +17,8 @@ from twisted.python.filepath import (
     InsecurePath,
 )
 from twisted.internet.defer import (
-    maybeDeferred,
+    inlineCallbacks,
+    returnValue,
 )
 from twisted.application.internet import (
     StreamServerEndpointService,
@@ -26,7 +27,6 @@ from twisted.web.resource import (
     NoResource,
 )
 from twisted.web.server import (
-    NOT_DONE_YET,
     Site,
 )
 from twisted.web import (
@@ -35,6 +35,9 @@ from twisted.web import (
 from twisted.web.resource import (
     Resource,
 )
+
+from klein import Klein
+
 from allmydata.uri import (
     from_string as tahoe_uri_from_string,
 )
@@ -119,13 +122,14 @@ class BearerTokenAuthorization(Resource, object):
         if _is_authorized(request, self._get_auth_token):
             # Authorization checks out, let the protected resource do what it
             # will.
-            return self._resource.getChildWithDefault(path, request)
+            request.postpath.insert(0, request.prepath.pop())
+            return self._resource
         # Don't let anything through that isn't authorized.
         return Unauthorized()
 
 
 @attr.s
-class APIv1(Resource, object):
+class APIv1(object):
     """
     Implement the ``/v1`` HTTP API hierarchy.
 
@@ -136,100 +140,55 @@ class APIv1(Resource, object):
     _global_service = attr.ib()
     _tahoe_client = attr.ib()
 
-    def __attrs_post_init__(self):
-        Resource.__init__(self)
-        self.putChild(b"magic-folder", MagicFolderAPIv1(self._global_config))
-        self.putChild(b"snapshot", SnapshotAPIv1(self._global_config, self._global_service))
-        self.putChild(b"participants", ParticipantsAPIv1(self._global_config, self._tahoe_client))
+    app = Klein()
 
-
-@attr.s
-class ParticipantsAPIv1(Resource, object):
-    """
-    Implements the ``/v1/participants`` portion of the HTTP API
-    resource hierarchy.
-
-    :ivar GlobalConfigDatabase _global_config: The global configuration for
-        this Magic Folder service.
-    """
-    _global_config = attr.ib()
-    _tahoe_client = attr.ib()
-
-    def __attrs_post_init__(self):
-        Resource.__init__(self)
-
-    def getChild(self, name, request):
-        name_u = name.decode("utf-8")
-        try:
-            folder_config = self._global_config.get_magic_folder(name_u)
-        except ValueError:
-            return NoResource(b"{}")
-        return MagicFolderParticipantAPIv1(folder_config, self._tahoe_client)
-
-
-class _InputError(ValueError):
-    """
-    Local errors with our input validation to report back to HTTP
-    clients.
-    """
-
-
-@attr.s
-class MagicFolderParticipantAPIv1(Resource, object):
-    """
-    Implements the v1 API for the ``/participants/<magic-folder-name>``
-    part of the API hierarchy.
-    """
-    _folder_config = attr.ib()
-    _tahoe_client = attr.ib()
-
-    # XXX maybe we could/should pass around a TahoeClient with the
-    # global-config? It could maybe simplify stuff, *so long as* we
-    # can still override a "testing" client into e.g. a "testing"
-    # config...
-
-    def __attrs_post_init__(self):
-        Resource.__init__(self)
-
-    def render_GET(self, request):
+    @app.route("/participants/<string:folder_name>", methods=['GET'])
+    @inlineCallbacks
+    def list_participants(self, request, folder_name):
         """
         List all participants of this folder
         """
+        try:
+            folder_config = self._global_config.get_magic_folder(folder_name)
+        except ValueError:
+            returnValue(NoResource(b"{}"))
+
         collective = participants_from_collective(
-            self._folder_config.collective_dircap,
-            self._folder_config.upload_dircap,
+            folder_config.collective_dircap,
+            folder_config.upload_dircap,
             self._tahoe_client,
         )
-        d = collective.list()
-
-        def listed(participants):
-            reply = {
-                part.name: {
-                    "personal_dmd": part.dircap.decode("ascii"),
-                    # not tracked properly yet
-                    # "public_key": part.verify_key.encode(Base32Encoder),
-                }
-                for part in participants
-            }
-            request.setResponseCode(http.OK)
-            _application_json(request)
-            request.write(json.dumps(reply).encode("utf8"))
-        d.addCallback(listed)
-
-        def failed(reason):
+        try:
+            participants = yield collective.list()
+        except Exception:
             # probably should log this failure
             request.setResponseCode(http.INTERNAL_SERVER_ERROR)
             _application_json(request)
-            request.write(json.dumps({"reason": "unexpected error processing request"}))
-            return None
-        d.addErrback(failed)
-        d.addBoth(lambda ignored: request.finish())
-        return NOT_DONE_YET
+            returnValue(json.dumps({"reason": "unexpected error processing request"}, ensure_ascii=False).encode("utf-8"))
 
-    def render_POST(self, request):
+        reply = {
+            part.name: {
+                "personal_dmd": part.dircap.decode("ascii"),
+                # not tracked properly yet
+                # "public_key": part.verify_key.encode(Base32Encoder),
+            }
+            for part in participants
+        }
+        request.setResponseCode(http.OK)
+        _application_json(request)
+        returnValue(json.dumps(reply, ensure_ascii=False).encode("utf8"))
+
+    @app.route("/participants/<string:folder_name>", methods=['POST'])
+    @inlineCallbacks
+    def add_participant(self, request, folder_name):
         """
         Add a new participant to this folder with details from the JSON-encoded body.
         """
+        try:
+            folder_config = self._global_config.get_magic_folder(folder_name)
+        except ValueError:
+            returnValue(NoResource(b"{}"))
+
         body = request.content.read()
         try:
             participant = json.loads(body)
@@ -265,50 +224,27 @@ class MagicFolderParticipantAPIv1(Resource, object):
             personal_dmd_cap = participant["personal_dmd"]
         except _InputError as e:
             request.setResponseCode(http.BAD_REQUEST)
-            return json.dumps({"reason": str(e)})
+            returnValue(json.dumps({"reason": str(e)}))
 
         collective = participants_from_collective(
-            self._folder_config.collective_dircap,
-            self._folder_config.upload_dircap,
+            folder_config.collective_dircap,
+            folder_config.upload_dircap,
             self._tahoe_client,
         )
-        d = collective.add(author, personal_dmd_cap)
-
-        def added(ignored):
-            request.setResponseCode(http.CREATED)
-            _application_json(request)
-            request.write(b"{}")
-            return None
-        d.addCallback(added)
-
-        def failed(reason):
+        try:
+            yield collective.add(author, personal_dmd_cap)
+        except Exception:
             request.setResponseCode(http.INTERNAL_SERVER_ERROR)
             _application_json(request)
             # probably should log this error, at least for developers (so eliot?)
-            request.write(json.dumps({"reason": "unexpected error processing request"}))
-            return None
-        d.addErrback(failed)
-        d.addBoth(lambda ignored: request.finish())
+            returnValue(json.dumps({"reason": "unexpected error processing request"}))
 
-        return NOT_DONE_YET
+        request.setResponseCode(http.CREATED)
+        _application_json(request)
+        returnValue(b"{}")
 
-
-@attr.s
-class SnapshotAPIv1(Resource, object):
-    """
-    ``SnapshotAPIv1`` implements the ``/v1/snapshot`` portion of the HTTP API
-    resource hierarchy.
-
-    :ivar GlobalConfigDatabase _global_config: The global configuration for
-        this Magic Folder service.
-    """
-    _global_config = attr.ib()
-    _global_service = attr.ib()
-
-    def __attrs_post_init__(self):
-        Resource.__init__(self)
-
-    def render_GET(self, request):
+    @app.route("/snapshot", methods=['GET'])
+    def list_all_sanpshots(self, request):
         """
         Respond with all of the snapshots for all of the files in all of the
         folders.
@@ -316,29 +252,19 @@ class SnapshotAPIv1(Resource, object):
         _application_json(request)
         return json.dumps(dict(_list_all_snapshots(self._global_config)))
 
-    def getChild(self, name, request):
-        name_u = name.decode("utf-8")
-        folder_config = self._global_config.get_magic_folder(name_u)
-        folder_service = self._global_service.get_folder_service(name_u)
-        return MagicFolderSnapshotAPIv1(folder_config, folder_service)
-
-
-@attr.s
-class MagicFolderSnapshotAPIv1(Resource, object):
-    """
-    """
-    _folder_config = attr.ib()
-    _folder_service = attr.ib()
-
-    def __attrs_post_init__(self):
-        Resource.__init__(self)
-
-    def render_POST(self, request):
+    @app.route("/snapshot/<string:folder_name>", methods=['POST'])
+    @inlineCallbacks
+    def add_snapshot(self, request, folder_name):
         """
         Create a new Snapshot
         """
-        path_u = request.args[b"path"][0].decode("utf-8")
+        try:
+            folder_config = self._global_config.get_magic_folder(folder_name)
+            folder_service = self._global_service.get_folder_service(folder_name)
+        except ValueError:
+            returnValue(NoResource(b"{}"))
 
+        path_u = request.args[b"path"][0].decode("utf-8")
 
         # preauthChild allows path-separators in the "path" (i.e. not
         # just a single path-segment). That is precisely what we want
@@ -348,34 +274,68 @@ class MagicFolderSnapshotAPIv1(Resource, object):
         # or a relative path that reaches up too far.
 
         try:
-            path = self._folder_config.magic_path.preauthChild(path_u)
+            path = folder_config.magic_path.preauthChild(path_u)
         except InsecurePath as e:
             request.setResponseCode(http.NOT_ACCEPTABLE)
             _application_json(request)
-            return json.dumps({u"reason": str(e)})
+            returnValue(json.dumps({u"reason": str(e)}))
 
-        adding = maybeDeferred(
-            self._folder_service.local_snapshot_service.add_file,
-            path,
-        )
-        def added(ignored):
-            request.setResponseCode(http.CREATED)
-            _application_json(request)
-            request.write(b"{}")
-
-        def failed(reason):
-            # XXX log this?
+        try:
+            yield folder_service.local_snapshot_service.add_file(path)
+        except Exception as e:
             request.setResponseCode(http.INTERNAL_SERVER_ERROR)
             _application_json(request)
-            request.write(json.dumps({u"reason": reason.getErrorMessage()}))
+            returnValue(json.dumps({u"reason": str(e)}))
 
-        adding.addCallbacks(
-            added,
-            failed,
-        ).addCallback(
-            lambda ignored: request.finish(),
-        )
-        return NOT_DONE_YET
+        request.setResponseCode(http.CREATED)
+        _application_json(request)
+        returnValue(b"{}")
+
+    @app.route("/magic-folder", methods=["GET"])
+    def list_folders(self, request):
+        """
+        Render a list of Magic Folders and some of their details, encoded as JSON.
+        """
+        include_secret_information = int(request.args.get("include_secret_information", [0])[0])
+        _application_json(request)  # set reply headers
+
+        def get_folder_info(name, mf):
+            info = {
+                u"name": name,
+                u"author": {
+                    u"name": mf.author.name,
+                    u"verify_key": mf.author.verify_key.encode(Base32Encoder),
+                },
+                u"stash_path": mf.stash_path.path,
+                u"magic_path": mf.magic_path.path,
+                u"poll_interval": mf.poll_interval,
+                u"is_admin": mf.is_admin(),
+            }
+            if include_secret_information:
+                info[u"author"][u"signing_key"] = mf.author.signing_key.encode(Base32Encoder)
+                info[u"collective_dircap"] = mf.collective_dircap
+                info[u"upload_dircap"] = mf.upload_dircap
+            return info
+
+        def all_folder_configs():
+            for name in sorted(self._global_config.list_magic_folders()):
+                yield (name, self._global_config.get_magic_folder(name))
+
+        return json.dumps({
+            name: get_folder_info(name, config)
+            for name, config
+            in all_folder_configs()
+        })
+
+
+
+
+class _InputError(ValueError):
+    """
+    Local errors with our input validation to report back to HTTP
+    clients.
+    """
+
 
 
 def _application_json(request):
@@ -484,55 +444,6 @@ def _snapshot_to_json(snapshot):
     return result
 
 
-@attr.s
-class MagicFolderAPIv1(Resource, object):
-    """
-    Implement the ``/v1/magic-folder`` HTTP API hierarchy.
-
-    :ivar GlobalConfigDatabase _global_config: The global configuration for
-        this Magic Folder service.
-    """
-    _global_config = attr.ib()
-
-    def __attrs_post_init__(self):
-        Resource.__init__(self)
-
-    def render_GET(self, request):
-        """
-        Render a list of Magic Folders and some of their details, encoded as JSON.
-        """
-        include_secret_information = int(request.args.get("include_secret_information", [0])[0])
-        _application_json(request)  # set reply headers
-
-        def get_folder_info(name, mf):
-            info = {
-                u"name": name,
-                u"author": {
-                    u"name": mf.author.name,
-                    u"verify_key": mf.author.verify_key.encode(Base32Encoder),
-                },
-                u"stash_path": mf.stash_path.path,
-                u"magic_path": mf.magic_path.path,
-                u"poll_interval": mf.poll_interval,
-                u"is_admin": mf.is_admin(),
-            }
-            if include_secret_information:
-                info[u"author"][u"signing_key"] = mf.author.signing_key.encode(Base32Encoder)
-                info[u"collective_dircap"] = mf.collective_dircap
-                info[u"upload_dircap"] = mf.upload_dircap
-            return info
-
-        def all_folder_configs():
-            for name in sorted(self._global_config.list_magic_folders()):
-                yield (name, self._global_config.get_magic_folder(name))
-
-        return json.dumps({
-            name: get_folder_info(name, config)
-            for name, config
-            in all_folder_configs()
-        })
-
-
 class Unauthorized(Resource):
     """
     An ``Unauthorized`` resource renders an HTTP *UNAUTHORIZED* response for
@@ -565,7 +476,7 @@ def magic_folder_web_service(web_endpoint, global_config, global_service, get_au
 
     :returns: a StreamServerEndpointService instance
     """
-    v1_resource = APIv1(global_config, global_service, tahoe_client)
+    v1_resource = APIv1(global_config, global_service, tahoe_client).app.resource()
     root = magic_folder_resource(get_auth_token, v1_resource)
     return StreamServerEndpointService(
         web_endpoint,

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -261,7 +261,7 @@ class APIv1(object):
         _application_json(request)
         returnValue(b"{}")
 
-    @app.route("/snapshot", methods=['GET'])
+    @app.route("/snapshots", methods=['GET'])
     def list_all_sanpshots(self, request):
         """
         Respond with all of the snapshots for all of the files in all of the


### PR DESCRIPTION
This is all the tests and none of the `web.py` changes from `359.http-api-layout` ... so if we adjust the klein-using code so that all the tests on this branch pass then we'd have #359 fixed and be using klein as the webserver...